### PR TITLE
Add 'tqdm' dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="bicon",
-    version="1.2.1",
+    version="1.2.2",
     author="Olga Lazareva",
     author_email="olga.lazareva@tum.de",
     description="BiCoN - a package for network-constrained biclustering of omics data",
@@ -28,7 +28,8 @@ setuptools.setup(
         'gseapy==0.9.15',
         'seaborn==0.9.0',
         'mygene==3.1.0',
-        'scikit_learn'
+        'scikit_learn',
+        'tqdm==4.45.0'
     ],
 
 )


### PR DESCRIPTION
Added missing `tqdm` dependency which failed the import of the BiCoN package.
Also bumped the version from 1.2.1 to 1.2.2

Closes #3 