### PR TITLE
Handle very small data sets

### DIFF
--- a/bicon/ants.py
+++ b/bicon/ants.py
@@ -83,7 +83,7 @@ class BiCoN(object):
         patients = np.arange(n, n + m)
         # cost of transitions for ants
         cost = H / 10
-        cost = np.max(cost) - cost
+        cost = 0.1 + np.max(cost) - cost
         # stores all scores
         scores = []
         avs = []


### PR DESCRIPTION
Add 0.1 to the cost matrix to avoid costs of 0.

Related to issue #5 